### PR TITLE
Omitting start for directions API

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ export function createMapLink({
 	}
 
 	// Directions if start and end is present
-	if (params.start && params.end) {
+	if (params.end) {
 		link.google = 'https://www.google.com/maps/dir/?api=1&';
 	}
 


### PR DESCRIPTION
Omitting the start param, like you should according to the docs, did not work on Android. Providing an empty string to start only worked for iOS as well.