### PR TITLE
Fix navigation message and conditional with no end destination

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,8 +227,8 @@ export function createMapLink(options) {
 		link.google = 'https://www.google.com/maps/@?api=1&map_action=map&';
 
 		// If navigate is navigate with lat and lng params
-		if (navigate === true) {
-			console.warn("Expected 'end' parameter in navigation, defaulting to preview mode.");
+		if (navigate === true && end === null) {
+			console.warn("Navigation mode set, but no end destination configured, defaulting to preview mode. If you meant to enable navigation for a destination, set the coordinates to the end parameter.");
 			options.navigate = false;
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-open-maps",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A simple react-native library to perform cross-platform map actions (Google, Apple, or Yandex Maps)",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
When enabling navigation on Google maps and only specifying coordinates, the library would just complain, but it should also be informing the user to set the coordinates to the end destination instead.

#63 #52 